### PR TITLE
#1: Update hseeberger/scala-sbt (closes #1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt
+FROM hseeberger/scala-sbt:8u222_1.3.7_2.12.10
 
 # Download and install wkhtmltopdf
 RUN apt-get update \


### PR DESCRIPTION
Closes [#2520893](https://buildo.kaiten.io/space/[object Object]/card/2520893)

⚠️ The line above was added during the automatic migration of all github project issues to Kaiten. The old GH issue link is kept here for reference (it is now deprecated, continue follow the original issue on Kaiten).

Closes #1

Builds successfully
