### PR TITLE
Use eclipse-temurin as base image instead of hseeberger/scala-sbt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,10 +40,10 @@ RUN apt-get update \
     libxext6 \
     libx11-6 \
     libxrender1 \
-    libjpeg-turbo8 \
-    && apt-get clean
+    libjpeg-turbo8
 
 RUN curl "https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb" -L -o "wkhtmltopdf.deb" \
     && dpkg -i ./wkhtmltopdf.deb \
     && apt-get install -f \
+    && apt-get clean \
     && rm -rf wkhtmlto*


### PR DESCRIPTION
This PR

- updates OpenJDK to 17 from 8
- updates Scala to 2.12.17 from 2.12.12
- updates wkhtmltopdf to 0.12.6.1-2 from 0.12.3
- downgrades sbt to 1.3.13 from 1.4.7

This image is based on Ubuntu since wkhtmltopdf does not work correctly on Alpine.